### PR TITLE
Modernize style with animations

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,11 +3,11 @@
 @tailwind utilities;
 
 :root {
-  --primary-dark: #151515;
-  --primary-red: #A91D3A;
-  --secondary-red: #C73659;
-  --light-gray: #5b5b5b;
-  --text-gray: #353434;
+  --primary-dark: #0f172a;
+  --primary-red: #7c3aed;
+  --secondary-red: #ec4899;
+  --light-gray: #f3f4f6;
+  --text-gray: #94a3b8;
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
+import { Poppins } from 'next/font/google'
 import './globals.css'
 import Navigation from '@/components/Navigation'
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import { Analytics } from "@vercel/analytics/next"
 
-const inter = Inter({ subsets: ['latin'] })
+const poppins = Poppins({ subsets: ['latin'], weight: ['400','700'] })
 
 export const metadata: Metadata = {
   title: 'Trent Hancock - Sr. Manufacturing Controls Engineer',
@@ -19,7 +19,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="scroll-smooth">
-      <body className={`${inter.className} bg-gray-50`}>
+      <body className={`${poppins.className} bg-primary-dark text-light-gray`}>
         <Navigation />
         {children}
         <SpeedInsights />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,10 +4,16 @@ import Experience from '@/components/Experience'
 import Skills from '@/components/Skills'
 import Education from '@/components/Education'
 import Contact from '@/components/Contact'
+import { motion } from 'framer-motion'
 
 export default function Home() {
   return (
-    <main className="min-h-screen">
+    <motion.main
+      className="min-h-screen"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.6 }}
+    >
       <Header />
       <div className="container mx-auto px-4 py-8 max-w-4xl">
         <Contact />
@@ -15,6 +21,6 @@ export default function Home() {
         <Experience />
         <Education />
       </div>
-    </main>
+    </motion.main>
   )
-} 
+}

--- a/src/app/personal/page.tsx
+++ b/src/app/personal/page.tsx
@@ -1,8 +1,14 @@
 import React from 'react'
+import { motion } from 'framer-motion'
 
 export default function PersonalPage() {
   return (
-    <main className="min-h-screen">
+    <motion.main
+      className="min-h-screen"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.6 }}
+    >
       <div className="bg-gradient-to-r from-primary-dark via-primary-red to-secondary-red text-light-gray py-16">
         <div className="container mx-auto px-4 max-w-4xl">
           <h1 className="text-4xl font-bold mb-4">Beyond Engineering</h1>
@@ -124,6 +130,6 @@ export default function PersonalPage() {
           </div>
         </div>
       </div>
-    </main>
+    </motion.main>
   )
-} 
+}

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,8 +1,15 @@
 import React from 'react'
+import { motion } from 'framer-motion'
 
 export default function Contact() {
   return (
-    <section className="mb-12 transform -mt-8">
+    <motion.section
+      className="mb-12 transform -mt-8"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+    >
       <div className="bg-primary-dark rounded-xl shadow-lg p-1">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-1">
           <a
@@ -60,6 +67,6 @@ export default function Contact() {
           </a>
         </div>
       </div>
-    </section>
+    </motion.section>
   )
-} 
+}

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -1,8 +1,15 @@
 import React from 'react'
+import { motion } from 'framer-motion'
 
 export default function Education() {
   return (
-    <section className="mb-12">
+    <motion.section
+      className="mb-12"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+    >
       <h2 className="text-2xl font-bold mb-6 text-primary-red">Education</h2>
       <div className="bg-primary-dark p-6 rounded-lg shadow-sm border border-primary-red/20">
         <div className="flex flex-col md:flex-row md:justify-between md:items-start">
@@ -13,6 +20,6 @@ export default function Education() {
           <p className="text-light-gray/80 mt-1 md:mt-0">2011 – 2014</p>
         </div>
       </div>
-    </section>
+    </motion.section>
   )
-} 
+}

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { motion } from 'framer-motion'
 
 interface ExperienceItem {
   title: string;
@@ -51,7 +52,13 @@ const experiences: ExperienceItem[] = [
 
 export default function Experience() {
   return (
-    <section className="mb-12">
+    <motion.section
+      className="mb-12"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+    >
       <h2 className="text-2xl font-bold mb-6 text-primary-red">Professional Experience</h2>
       <div className="space-y-8">
         {experiences.map((exp, index) => (
@@ -73,6 +80,6 @@ export default function Experience() {
           </div>
         ))}
       </div>
-    </section>
+    </motion.section>
   );
-} 
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,22 +1,47 @@
 import React from 'react'
 import Image from 'next/image'
+import { motion } from 'framer-motion'
 
 export default function Header() {
   return (
-    <header className="relative bg-gradient-to-r from-primary-dark via-primary-red to-secondary-red text-light-gray py-24">
+    <motion.header
+      initial={{ opacity: 0, y: -40 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.8 }}
+      className="relative bg-gradient-to-r from-primary-dark via-primary-red to-secondary-red text-light-gray py-24"
+    >
       <div className="absolute inset-0 bg-grid-white/[0.05] bg-[size:20px_20px]" />
       <div className="container mx-auto px-4 max-w-4xl relative">
         <div className="flex flex-col md:flex-row md:items-center md:justify-between">
           <div className="mb-8 md:mb-0">
             <h1 className="text-5xl font-bold mb-4 tracking-tight">
-              <span className="block transform hover:scale-105 transition-transform duration-200">TRENT</span>
-              <span className="block transform hover:scale-105 transition-transform duration-200 delay-75">HANCOCK</span>
+              <motion.span
+                className="block transform hover:scale-105"
+                initial={{ x: -50, opacity: 0 }}
+                animate={{ x: 0, opacity: 1 }}
+                transition={{ duration: 0.6 }}
+              >
+                TRENT
+              </motion.span>
+              <motion.span
+                className="block transform hover:scale-105"
+                initial={{ x: 50, opacity: 0 }}
+                animate={{ x: 0, opacity: 1 }}
+                transition={{ duration: 0.6, delay: 0.2 }}
+              >
+                HANCOCK
+              </motion.span>
             </h1>
             <h2 className="text-2xl font-light mb-6 text-light-gray">
               Sr. Manufacturing Controls Engineer
             </h2>
           </div>
-          <div className="relative w-32 h-32 rounded-full overflow-hidden bg-light-gray/10 backdrop-blur-sm">
+          <motion.div
+            className="relative w-32 h-32 rounded-full overflow-hidden bg-light-gray/10 backdrop-blur-sm"
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            transition={{ duration: 0.6, delay: 0.3 }}
+          >
             <Image
               src="/profile.png"
               alt="Trent Hancock"
@@ -24,17 +49,22 @@ export default function Header() {
               className="object-cover"
               priority
             />
-          </div>
+          </motion.div>
         </div>
-        <div className="mt-8 bg-light-gray/10 backdrop-blur-sm p-6 rounded-lg transform hover:scale-[1.02] transition-transform duration-200">
+        <motion.div
+          className="mt-8 bg-light-gray/10 backdrop-blur-sm p-6 rounded-lg transform hover:scale-[1.02] transition-transform duration-200"
+          initial={{ opacity: 0, y: 40 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8, delay: 0.6 }}
+        >
           <p className="text-lg leading-relaxed text-light-gray">
-            A motivated Senior Manufacturing Controls Engineer with a proven track record in optimizing complex manufacturing processes. 
-            Combining deep technical expertise with a passion for engineering, I specialize in developing automation 
-            solutions that drive operational efficiency. Whether it's implementing control systems or mentoring future engineers, 
+            A motivated Senior Manufacturing Controls Engineer with a proven track record in optimizing complex manufacturing processes.
+            Combining deep technical expertise with a passion for engineering, I specialize in developing automation
+            solutions that drive operational efficiency. Whether it's implementing control systems or mentoring future engineers,
             I bring the same level of dedication and innovation to every project.
           </p>
-        </div>
+        </motion.div>
       </div>
-    </header>
+    </motion.header>
   )
-} 
+}

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { motion } from 'framer-motion'
 
 interface SkillCategory {
   name: string;
@@ -109,7 +110,13 @@ const skillCategories: SkillCategory[] = [
 
 export default function Skills() {
   return (
-    <section className="mb-12">
+    <motion.section
+      className="mb-12"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.6 }}
+    >
       <h2 className="text-2xl font-bold mb-6 text-primary-red">Expertise</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {skillCategories.map((category, index) => (
@@ -149,6 +156,6 @@ export default function Skills() {
           </div>
         ))}
       </div>
-    </section>
+    </motion.section>
   )
-} 
+}


### PR DESCRIPTION
## Summary
- switch to a purple themed palette
- use Poppins font globally
- animate header elements and profile image
- fade in main sections across the site

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c3336d34832790a676acfbac66c0